### PR TITLE
Restructure crate to resemble typical multi-bin project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gddimagine2020-altctrl-deathpanel"
+name = "altctrl"
 version = "0.1.0"
 authors = ["joseph <josephbgerber@gmail.com>", "willnilges <will.nilges@gmail.com>"]
 edition = "2018"
@@ -17,17 +17,17 @@ i2cdev = "0.4.2"
 rppal = "0.11.3"
 
 [lib]
-name = "gui_lib"
-path = "src/gui/gui_lib.rs"
+name = "altctrl"
+path = "src/lib.rs"
 
 [[bin]]
 name = "chungo"
-path = "src/chungo.rs"
+path = "src/bin/chungo.rs"
 
 [[bin]]
 name = "garfanzo"
-path = "src/garfanzo.rs"
+path = "src/bin/garfanzo.rs"
 
 [[bin]]
 name = "fatkhiyev"
-path = "src/fatkhiyev.rs"
+path = "src/bin/fatkhiyev.rs"

--- a/src/bin/chungo.rs
+++ b/src/bin/chungo.rs
@@ -7,13 +7,8 @@ use std::io::{BufRead, BufReader, Write};
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 
-mod gui;
-mod i2c;
-mod protocol;
-mod shared;
-
-use protocol::{IncomingMsg, OutgoingMsg};
-use shared::{Event, SerialEvent};
+use altctrl::{Event, SerialEvent};
+use altctrl::protocol::{IncomingMsg, OutgoingMsg};
 
 // Default serial port location on the raspberry pi
 const PORT: &str = "/dev/serial0";
@@ -59,5 +54,5 @@ pub fn launch(tx: Sender<Event>, rx: Receiver<SerialEvent>) {
 
 // Launch the main thread using a serial interface
 fn main() {
-    shared::start(launch);
+    altctrl::start(launch);
 }

--- a/src/bin/fatkhiyev.rs
+++ b/src/bin/fatkhiyev.rs
@@ -5,13 +5,9 @@ use std::net::TcpListener;
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 
-mod gui;
-mod i2c;
-mod protocol;
-mod shared;
-
-use protocol::{IncomingMsg, OutgoingMsg};
-use shared::{Event, SerialEvent};
+use altctrl::gui;
+use altctrl::{Event, SerialEvent};
+use altctrl::protocol::{IncomingMsg, OutgoingMsg};
 
 // Launch function for an interface module using i2c for communication
 pub fn launch(tx: Sender<Event>, rx: Receiver<SerialEvent>) {
@@ -58,5 +54,5 @@ pub fn launch(tx: Sender<Event>, rx: Receiver<SerialEvent>) {
 
 // Launch the main thread using a tcp interface
 fn main() {
-    shared::start(launch);
+    altctrl::start(launch);
 }

--- a/src/bin/garfanzo.rs
+++ b/src/bin/garfanzo.rs
@@ -3,12 +3,11 @@ use std::io;
 use std::io::prelude::*;
 use std::sync::mpsc::{Receiver, Sender};
 
-mod gui;
-mod i2c;
-mod protocol;
-mod shared;
-
-use shared::{Event, SerialEvent};
+use altctrl::{
+    self,
+    Event,
+    SerialEvent,
+};
 
 pub fn launch(tx: Sender<Event>, rx: Receiver<SerialEvent>) {
     let mut file = File::create("/tmp/altctrl.serial").unwrap();
@@ -36,5 +35,5 @@ pub fn launch(tx: Sender<Event>, rx: Receiver<SerialEvent>) {
 }
 
 fn main() {
-    shared::start(launch);
+    altctrl::start(launch);
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,16 +1,12 @@
-extern crate ncurses;
-extern crate gui_lib;
-
-
 use std::collections::HashMap;
 use std::sync::mpsc::{Sender, Receiver};
 use ncurses::*;
 
-use crate::shared::Event;
+pub mod gui_lib;
+
+use crate::Event;
 use crate::protocol::NewWindow;
 use gui_lib::*;
-
-
 
 #[derive(Clone, Debug)]
 pub enum GuiEvent{

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -14,8 +14,7 @@ mod button;
 use constants::*;
 use button::ButtonStruct;
 
-use crate::shared::{Event, SerialEvent};
-
+use crate::{Event, SerialEvent};
 use crate::protocol::*;
 
 #[derive(Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
-use std::sync::mpsc;
-use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
+use std::sync::mpsc::{self, Receiver, Sender};
 
-use crate::gui;
-use crate::i2c;
-use crate::protocol::{Button, Device, IncomingMsg};
+pub mod gui;
+pub mod i2c;
+pub mod protocol;
+
+use protocol::{Button, Device, IncomingMsg};
 
 // Represents all messages sent between modules
 #[derive(Clone, Debug)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::shared::SerialEvent;
+use crate::SerialEvent;
 
 // New window struct
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
All this does is move some files around.

- [x] Places all binaries into `src/bin`
- [x] Moves all shared code from `shared` into `src/lib.rs`
- [x] Imports shared library code into binaries using `use altctrl::blah`

From now on, consider anything belonging to `lib.rs` or anything that belongs to the module structure of the library (i.e. any module that can be found by following the `pub mod` path starting in `lib.rs`) as shared code. Any of the binaries can access the shared code just by using `use altctrl` e.g. with `use altctrl::i2c::thing` or `use altctrl::gui::thing`.

Future recommendations:

* Rather than having a file called `gui/gui_lib.rs`, just put all of that shared code into `gui/mod.rs`. That way, suppose you have a function called `foo` in gui, you could access that by calling `altctrl::gui::foo`.
* Currently, `usr_ctrl` is not part of the module structure (i.e. there is no `mod usr_ctrl` anywhere), therefore the code is not even being built by cargo, so it's quite possible that there's broken code in there. I'd recommend either adding that to the project structure or removing it.