### PR TITLE
Window steroids

### DIFF
--- a/src/gui/gui_lib.rs
+++ b/src/gui/gui_lib.rs
@@ -26,6 +26,27 @@ pub fn close_win(window: String, windows: &mut HashMap<String,WINDOW>, logbuffer
     }
 }
 
+pub fn clear_windows(windows: &mut HashMap<String, WINDOW>, logbuffer: &mut Vec<String>) {
+    // let mut WINDOW;
+    for (title, win) in &*windows {
+        match title.as_ref() {
+            "mainwindow" => { },
+            _ => {
+                let ch = ' ' as chtype;
+                wborder(*win, ch, ch, ch, ch, ch, ch, ch, ch);
+                wrefresh(*win);
+                delwin(*win);
+                logbuffer.insert(0, format!("Window \"{}\" destroyed.", title).to_string());
+                showlog(&logbuffer);
+            }
+        }
+    }
+    windows.clear();
+    logbuffer.insert(0, "Cleared all windows.".to_string());
+    showlog(&logbuffer);
+}
+
+
 pub fn open_win(x_loc: i32,
                  y_loc: i32,
                  x_dim: i32,
@@ -112,6 +133,7 @@ pub fn open_win(x_loc: i32,
                 mvprintw(start_y+1, start_x+1+(i as i32), " ");
             }
             attroff(A_STANDOUT());
+            // Print the value
             attron(A_BOLD());
             let progress_string = format!("|{}/{}|", lower, upper);
             mvprintw(start_y+y_dim+1, start_x+1, &progress_string);
@@ -122,7 +144,6 @@ pub fn open_win(x_loc: i32,
             showlog(&logbuffer);
         },
     }
-    
     box_(win, 0, 0);
     wrefresh(win);
     attron(A_BOLD());

--- a/src/gui/gui_lib.rs
+++ b/src/gui/gui_lib.rs
@@ -25,6 +25,7 @@ pub fn close_win(window: String, windows: &mut HashMap<String,(WINDOW, WindowDat
             }
         }
     }
+    redraw(windows);
 }
 
 pub fn clear_windows(windows: &mut HashMap<String, (WINDOW, WindowData)>, logbuffer: &mut Vec<String>) {
@@ -123,7 +124,7 @@ pub fn draw_win(new_window: &WindowData, win: WINDOW) {
             }
             attroff(A_UNDERLINE());
         },
-        "ProgressBar" | "PB" | "ProgBar" => { // Display a bar of some sort in a window.
+        "ProgressBar" | "PB" | "ProgBar" | "Bar" | "B" => { // Display a bar of some sort in a window.
                                               // (Window heights of 1 work best).
             let metrics = message.split('|').collect::<Vec<&str>>();
             let lower = metrics[0].parse::<f32>().unwrap();

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -79,14 +79,13 @@ pub fn launch(_tx: Sender<Event>, rx: Receiver<GuiEvent>) {
                 logbuffer.insert(0, open_windows.to_string());
             }
             GuiEvent::Clear() => {
-                clear(); 
-                /*
-                let mut wumbows: std::collections::HashMap<String, WINDOW> = &mut windows;
-                for (key, value) in &windows {
-                    close_win(key.to_string(), &mut windows, &mut logbuffer);
-                }
+                clear();
+                clear_windows(&mut windows, &mut logbuffer);
+                // let wumbows = &windows;
+                // for (key, _value) in wumbows {
+                //     close_win(key.to_string(), &mut windows, &mut logbuffer);
+                // }
                 showlog(&logbuffer);
-                */
             }
         }
         showlog(&logbuffer);

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,13 +4,13 @@ use std::sync::mpsc::{Receiver, Sender};
 
 pub mod gui_lib;
 
-use crate::protocol::NewWindow;
+use crate::protocol::WindowData;
 use crate::Event;
 use gui_lib::*;
 
 #[derive(Clone, Debug)]
 pub enum GuiEvent {
-    CreateWindow(NewWindow),
+    CreateWindow(WindowData),
     DestroyWindow(String),
     Log(String),
     List(),
@@ -31,7 +31,7 @@ pub fn launch(_tx: Sender<Event>, rx: Receiver<GuiEvent>) {
 
     // Set up omniscient stuff
     // HashMap of active windows, so that we know what's bonkin'
-    let mut windows: std::collections::HashMap<String, WINDOW> = HashMap::new();
+    let mut windows: std::collections::HashMap<String, (WINDOW, WindowData)> = HashMap::new();
     // Log buffer to use for keeping track of command output.
     let mut logbuffer: Vec<String> = Vec::new();
     for _i in 0..5 {
@@ -51,17 +51,7 @@ pub fn launch(_tx: Sender<Event>, rx: Receiver<GuiEvent>) {
         refresh();
         match message {
             GuiEvent::CreateWindow(new_window) => {
-                open_win(
-                    new_window.x_pos,
-                    new_window.y_pos,
-                    new_window.width,
-                    new_window.height,
-                    &new_window.id,
-                    &new_window.content,
-                    &new_window.message,
-                    &mut windows,
-                    &mut logbuffer,
-                );
+                open_win(new_window, &mut windows, &mut logbuffer);
             }
             GuiEvent::DestroyWindow(id) => {
                 close_win(id, &mut windows, &mut logbuffer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ impl AltctrlInterface for Garfanzo {
                                                             .to_string(),
                                                     )))
                                                     .unwrap();
-                                                let window = protocol::NewWindow {
+                                                let window = protocol::WindowData {
                                                     id:      command[2].to_string(),
                                                     content: command[3].to_string(),
                                                     message: command[4].to_string(),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,7 +6,7 @@ use crate::SerialEvent;
 
 // New window struct
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct NewWindow {
+pub struct WindowData {
     pub id: String,
     pub content: String,
     pub message: String,
@@ -16,14 +16,14 @@ pub struct NewWindow {
     pub height: i32,
 }
 
-//Contents of window.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum WindowContent {
-    Text,
-    List,
-    Scoreboard,
-    ProgressBar,
-}
+//Contents of window. (UNUSED)
+// #[derive(Clone, Debug, Serialize, Deserialize)]
+// pub enum WindowContent {
+//     Text,
+//     List,
+//     Scoreboard,
+//     ProgressBar,
+// }
 
 // Represents a device in the system
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -48,7 +48,7 @@ pub enum Port {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum IncomingMsg {
-    CreateWindow { window: NewWindow },
+    CreateWindow { window: WindowData },
     DestroyWindow { id: String },
     On { device: Device, port: Port },
     Off { device: Device, port: Port },


### PR DESCRIPTION
You should merge #42 first.

This adds a way to close all open windows on the HUD with one command. Will probably come in handy.

Close #43 
Close #45

## Oh, and by the way...

Completely reconfigure the window management system and window tracking.

There are now three major items tracked in the HashMap: `name`, `WINDOW`, and `WindowData`. `WindowData` is the renamed `NewWindow`.  This was done to help with #43 and #45.

Reorganizes the `new_window` function into a few discrete parts. Firstly, `new_window` which creates, tracks, and draws a new window, and then a window drawing function separate, and then a redrawing function salso separate. Should reduce coupling and make the whole system a little more flexible.

Redraw works. Whenever a window is uncovered after one goes away, it'll get redrawn.

At present, I see no bugs. *There are probably bugs.*

Ref. e30deaa and 9b47cab