### PR TITLE
Rewrite Garfanzo with clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ ncurses = "5.99.0"
 
 i2cdev = "0.4.2"
 rppal = "0.11.3"
+regex = "1.3.3"
+lazy_static = "1.4.0"
 
 [lib]
 name = "altctrl"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -24,16 +24,6 @@ fn main() {
         )
         .get_matches();
 
-    let interface: Box<dyn AltctrlInterface + Send> = match matches.value_of("interface") {
-        Some("chungo") => Box::new(altctrl::Chungo::new("/dev/ttyGS0")),
-        Some("garfanzo") => Box::new(altctrl::Garfanzo),
-        Some("fatkhiyev") => Box::new(altctrl::Fatkhiyev::new("0.0.0.0:6969")),
-        Some(_) | None => {
-            println!("Invalid interface (or no interface provided)");
-            return;
-        }
-    };
-
     let disable_i2c = matches.is_present("disable-i2c");
 
     //Outcoming message channel for all modules
@@ -42,6 +32,18 @@ fn main() {
     //Incoming message channels for specific modules
     let (gui_tx, gui_rx) = mpsc::channel();
     let (serial_tx, serial_rx) = mpsc::channel();
+
+    let clone_tx = tx.clone();
+
+    let interface: Box<dyn AltctrlInterface + Send> = match matches.value_of("interface") {
+        Some("chungo") => Box::new(altctrl::Chungo::new("/dev/ttyGS0")),
+        Some("garfanzo") => Box::new(altctrl::Garfanzo::new(clone_tx)),
+        Some("fatkhiyev") => Box::new(altctrl::Fatkhiyev::new("0.0.0.0:6969")),
+        Some(_) | None => {
+            println!("Invalid interface (or no interface provided)");
+            return;
+        }
+    };
 
     let clone_tx = tx.clone();
 

--- a/src/garfanzo.rs
+++ b/src/garfanzo.rs
@@ -50,10 +50,11 @@ impl Garfanzo {
             .arg(Arg::with_name("toggle")
                 .help("Toggle the log window")
                 .long("--toggle").short("t")
-                .takes_value(false).required(false))
+                .takes_value(false))
             .arg(Arg::with_name("message")
                 .help("The message to print to the log window")
-                .index(1).takes_value(true).required(false))
+                .index(1)
+                .takes_value(true))
     }
 
     fn subcommand_window<'a, 'b>() -> App<'a, 'b> {
@@ -71,30 +72,30 @@ impl Garfanzo {
         SubCommand::with_name("new")
             .about("Creates a new window")
             .arg(Arg::with_name("id").help("The ID of the window to create")
-                .index(1).required(false).takes_value(true))
+                .index(1).takes_value(true))
             // TODO fill in content help
             .arg(Arg::with_name("content").help("TODO I don't know what this does")
-                .index(2).required(false).takes_value(true))
+                .index(2).takes_value(true))
             // TODO fill in message help
             .arg(Arg::with_name("message").help("TODO I don't know what this does")
-                .index(3).required(false).takes_value(true))
+                .index(3).takes_value(true))
             // TODO fill in style help
             .arg(Arg::with_name("style").help("TODO I don't know what this does")
-                .index(4).required(false).takes_value(true))
+                .index(4).takes_value(true))
             .arg(Arg::with_name("x_pos").help("The X coordinate of the window to create")
-                .index(5).required(false).takes_value(true)
+                .index(5).takes_value(true)
                 .validator(|x_pos| x_pos.parse::<i32>().map(|_| ()).map_err(|_| format!("x_pos must be an integer"))))
             .arg(Arg::with_name("y_pos").help("The Y coordinate of the window to create")
-                .index(6).required(false).takes_value(true)
+                .index(6).takes_value(true)
                 .validator(|y_pos| y_pos.parse::<i32>().map(|_| ()).map_err(|_| format!("y_pos must be an integer"))))
             .arg(Arg::with_name("width").help("The width of the window to create")
-                .index(7).required(false).takes_value(true)
+                .index(7).takes_value(true)
                 .validator(|w| w.parse::<i32>().map(|_| ()).map_err(|_| format!("width must be an integer"))))
             .arg(Arg::with_name("height").help("The height of the window to create")
-                .index(8).required(false).takes_value(true)
+                .index(8).takes_value(true)
                 .validator(|h| h.parse::<i32>().map(|_| ()).map_err(|_| format!("height must be an integer"))))
             .arg(Arg::with_name("priority").help("TODO I don't know what this does")
-                .index(9).required(false).takes_value(false).short("!"))
+                .index(9).takes_value(false).short("!"))
     }
 
     fn subcommand_window_close<'a, 'b>() -> App<'a, 'b> {
@@ -292,6 +293,7 @@ impl AltctrlInterface for Garfanzo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::ErrorKind;
 
     #[test]
     fn test_subcommand_window() {
@@ -312,6 +314,34 @@ mod tests {
                 assert_eq!(sub.value_of("y_pos"), Some("15"));
                 assert_eq!(sub.value_of("width"), Some("20"));
                 assert_eq!(sub.value_of("height"), Some("25"));
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_int_validator() {
+        let mut app = Garfanzo::app();
+        let command = vec!["window", "new", "0", "Hello, world", "message", "bold", "ten", "15", "20", "25"];
+        let result = app.get_matches_from_safe_borrow(command);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn test_priority() {
+        let mut app = Garfanzo::app();
+        let command = vec!["window", "new", "0", "Hello", "message", "bold", "10", "20", "30", "40", "!"];
+        let result = app.get_matches_from_safe_borrow(command);
+        assert!(result.is_ok());
+        let matches = result.unwrap();
+        if let ("window", Some(win_sub)) = matches.subcommand() {
+            if let ("new", Some(new_sub)) = win_sub.subcommand() {
+                assert!(new_sub.is_present("priority"));
             } else {
                 assert!(false);
             }

--- a/src/garfanzo.rs
+++ b/src/garfanzo.rs
@@ -1,192 +1,322 @@
-use crate::{AltctrlInterface, Event, SerialEvent, gui, protocol};
+use crate::{AltctrlInterface, Event, SerialEvent, protocol};
 use std::sync::mpsc::{Sender, Receiver};
-use std::{thread, io};
 use std::io::BufRead;
+use clap::{App, SubCommand, Arg, ArgMatches, AppSettings};
+use crate::gui::GuiEvent;
 
-pub struct Garfanzo;
+pub struct Garfanzo {
+    event_queue: Sender<Event>,
+}
+
+impl Garfanzo {
+    pub fn new(event_queue: Sender<Event>) -> Garfanzo {
+        Garfanzo { event_queue }
+    }
+
+    pub fn repl<B: BufRead>(&self, reader: B) {
+        let mut app = Self::app();
+        for line in reader.lines() {
+            let line = match line {
+                Err(_) => return,
+                Ok(line) => line,
+            };
+            let command = line.split(" ");
+            let matches = app.get_matches_from_safe_borrow(command);
+            match matches {
+                Ok(matches) => self.execute(&matches),
+                _ => {
+                    Self::app().write_help(&mut std::io::stderr()).unwrap();
+                    eprintln!();
+                },
+            }
+        }
+    }
+
+    pub fn app<'a, 'b>() -> App<'a, 'b> {
+        App::new("garfanzo")
+            .setting(AppSettings::UnifiedHelpMessage)
+            .setting(AppSettings::NoBinaryName)
+            .subcommand(Self::subcommand_log())
+            .subcommand(Self::subcommand_window())
+            .subcommand(SubCommand::with_name("redraw")
+                .about("Redraws the entire screen"))
+            .subcommand(SubCommand::with_name("clear")
+                .about("Clears the screen"))
+    }
+
+    fn subcommand_log<'a, 'b>() -> App<'a, 'b> {
+        SubCommand::with_name("log")
+            .about("Controls the log console")
+            .arg(Arg::with_name("toggle")
+                .help("Toggle the log window")
+                .long("--toggle").short("t")
+                .takes_value(false).required(false))
+            .arg(Arg::with_name("message")
+                .help("The message to print to the log window")
+                .index(1).takes_value(true).required(false))
+    }
+
+    fn subcommand_window<'a, 'b>() -> App<'a, 'b> {
+        SubCommand::with_name("window")
+            .about("Creates and controls windows")
+            .subcommand(Self::subcommand_window_new())
+            .subcommand(Self::subcommand_window_close())
+            .subcommand(Self::subcommand_window_move())
+            .subcommand(Self::subcommand_window_resize())
+            .subcommand(SubCommand::with_name("list").alias("ls")
+                .about("Lists all of the existing windows"))
+    }
+
+    fn subcommand_window_new<'a, 'b>() -> App<'a, 'b> {
+        SubCommand::with_name("new")
+            .about("Creates a new window")
+            .arg(Arg::with_name("id").help("The ID of the window to create")
+                .index(1).required(false).takes_value(true))
+            // TODO fill in content help
+            .arg(Arg::with_name("content").help("TODO I don't know what this does")
+                .index(2).required(false).takes_value(true))
+            // TODO fill in message help
+            .arg(Arg::with_name("message").help("TODO I don't know what this does")
+                .index(3).required(false).takes_value(true))
+            // TODO fill in style help
+            .arg(Arg::with_name("style").help("TODO I don't know what this does")
+                .index(4).required(false).takes_value(true))
+            .arg(Arg::with_name("x_pos").help("The X coordinate of the window to create")
+                .index(5).required(false).takes_value(true)
+                .validator(|x_pos| x_pos.parse::<i32>().map(|_| ()).map_err(|_| format!("x_pos must be an integer"))))
+            .arg(Arg::with_name("y_pos").help("The Y coordinate of the window to create")
+                .index(6).required(false).takes_value(true)
+                .validator(|y_pos| y_pos.parse::<i32>().map(|_| ()).map_err(|_| format!("y_pos must be an integer"))))
+            .arg(Arg::with_name("width").help("The width of the window to create")
+                .index(7).required(false).takes_value(true)
+                .validator(|w| w.parse::<i32>().map(|_| ()).map_err(|_| format!("width must be an integer"))))
+            .arg(Arg::with_name("height").help("The height of the window to create")
+                .index(8).required(false).takes_value(true)
+                .validator(|h| h.parse::<i32>().map(|_| ()).map_err(|_| format!("height must be an integer"))))
+            .arg(Arg::with_name("priority").help("TODO I don't know what this does")
+                .index(9).required(false).takes_value(false).short("!"))
+    }
+
+    fn subcommand_window_close<'a, 'b>() -> App<'a, 'b> {
+        SubCommand::with_name("close")
+            .about("Closes an existing window")
+            .arg(Arg::with_name("id").help("The ID of the window to close")
+                .index(1).takes_value(true))
+    }
+
+    fn subcommand_window_move<'a, 'b>() -> App<'a, 'b> {
+        SubCommand::with_name("move")
+            .about("Move an existing window to new coordinates")
+            .arg(Arg::with_name("id").help("The ID of the window to move")
+                .index(1).takes_value(true))
+            .arg(Arg::with_name("x_pos").help("The X coordinate to move the window to")
+                .index(2).takes_value(true))
+            .arg(Arg::with_name("y_pos").help("The Y coordinate to move the window to")
+                .index(3).takes_value(true))
+    }
+
+    fn subcommand_window_resize<'a, 'b>() -> App<'a, 'b> {
+        SubCommand::with_name("resize")
+            .about("Resizes an existing window")
+            .arg(Arg::with_name("id").help("The ID of the window to resize")
+                .index(1).takes_value(true))
+            .arg(Arg::with_name("width").help("The new width for the window")
+                .index(2).takes_value(true)
+                .validator(|w| w.parse::<i32>().map(|_| ()).map_err(|_| format!("width must be an integer"))))
+            .arg(Arg::with_name("height").help("The new height for the window")
+                .index(3).takes_value(true)
+                .validator(|h| h.parse::<i32>().map(|_| ()).map_err(|_| format!("height must be an integer"))))
+    }
+
+    pub fn execute(&self, args: &ArgMatches) {
+        match args.subcommand() {
+            ("log", Some(log_args)) => self.execute_log(log_args),
+            ("window", Some(window_args)) => self.execute_window(window_args),
+            ("redraw", _) => self.execute_redraw(),
+            ("clear", _) => self.execute_clear(),
+            _ => {
+                Self::app().write_help(&mut std::io::stderr()).unwrap();
+                eprintln!();
+            },
+        }
+    }
+
+    fn execute_log(&self, args: &ArgMatches) {
+        if args.is_present("toggle") {
+            self.event_queue.send(Event::Gui(GuiEvent::ToggleConsole())).unwrap();
+            return;
+        }
+
+        if let Some(message) = args.value_of("message") {
+            self.log(message);
+            return;
+        }
+
+        Self::subcommand_log().write_help(&mut std::io::stderr()).unwrap();
+        eprintln!();
+    }
+
+    fn log<S: AsRef<str>>(&self, msg: S) {
+        let msg = msg.as_ref();
+        self.event_queue.send(Event::Gui(GuiEvent::Log(msg.to_string()))).unwrap();
+    }
+
+    fn execute_window(&self, args: &ArgMatches) {
+        match args.subcommand() {
+            ("new", Some(new_args)) => self.execute_window_new(new_args),
+            ("close", Some(close_args)) => self.execute_window_close(close_args),
+            ("move", Some(move_args)) => self.execute_window_move(move_args),
+            ("list", _) => self.event_queue.send(Event::Gui(GuiEvent::List())).unwrap(),
+            ("resize", Some(resize_args)) => self.execute_window_resize(resize_args),
+            _ => {
+                Self::subcommand_window().write_help(&mut std::io::stderr()).unwrap();
+                eprintln!();
+            },
+        }
+    }
+
+    fn execute_window_new(&self, args: &ArgMatches) {
+        let id = args.value_of("id");
+        let content = args.value_of("content");
+        let message = args.value_of("message");
+        let style = args.value_of("style");
+        let x_pos = args.value_of("x_pos");
+        let y_pos = args.value_of("y_pos");
+        let width = args.value_of("width");
+        let height = args.value_of("height");
+        let priority = args.is_present("priority");
+
+        let required_args = vec![id, content, message, style, x_pos, y_pos, width, height];
+        if required_args.iter().any(|item| item.is_none()) {
+            Self::subcommand_window_new().write_help(&mut std::io::stderr()).unwrap();
+            eprintln!();
+            return;
+        }
+
+        // Required args have been checked, unwrap all.
+        let id = id.unwrap().to_string();
+        let content = content.unwrap().to_string();
+        let message = message.unwrap().to_string();
+        let style = style.unwrap().to_string();
+        let x_pos = x_pos.unwrap();
+        let y_pos = y_pos.unwrap();
+        let width = width.unwrap();
+        let height = height.unwrap();
+
+        // These already passed validation so unwrapping is safe
+        let x_pos: i32 = x_pos.parse().unwrap();
+        let y_pos: i32 = y_pos.parse().unwrap();
+        let width: i32 = width.parse().unwrap();
+        let height: i32 = height.parse().unwrap();
+
+        self.log(format!("Creating window \"{}\"", &id));
+        let window = protocol::WindowData {
+            id, content, message, style, x_pos, y_pos, width, height, priority
+        };
+        self.event_queue.send(Event::Gui(GuiEvent::CreateWindow(window))).unwrap();
+    }
+
+    fn execute_window_close(&self, args: &ArgMatches) {
+        let id = args.value_of("if");
+        if id.is_none() {
+            Self::subcommand_window_close().write_help(&mut std::io::stderr()).unwrap();
+            eprintln!();
+            return;
+        }
+
+        let id = id.unwrap().to_string();
+        self.log(format!("Closing window \"{}\"", id));
+        self.event_queue.send(Event::Gui(GuiEvent::DestroyWindow(id))).unwrap();
+    }
+
+    fn execute_window_move(&self, args: &ArgMatches) {
+        let id = args.value_of("id");
+        let x_pos = args.value_of("x_pos");
+        let y_pos = args.value_of("y_pos");
+
+        let required_args = vec![id, x_pos, y_pos];
+        if required_args.iter().any(|item| item.is_none()) {
+            Self::subcommand_window_move().write_help(&mut std::io::stderr()).unwrap();
+            eprintln!();
+            return;
+        }
+
+        let id = id.unwrap().to_string();
+        let x_pos = x_pos.unwrap();
+        let y_pos = y_pos.unwrap();
+
+        let x_pos: i32 = x_pos.parse().unwrap();
+        let y_pos: i32 = y_pos.parse().unwrap();
+        self.log(format!("Moving window \"{}\"", id));
+        self.event_queue.send(Event::Gui(GuiEvent::MoveWindow(id, x_pos, y_pos))).unwrap();
+    }
+
+    fn execute_window_resize(&self, args: &ArgMatches) {
+        let id = args.value_of("id");
+        let width = args.value_of("width");
+        let height = args.value_of("height");
+
+        let required_args = vec![id, width, height];
+        if required_args.iter().any(|item| item.is_none()) {
+            Self::subcommand_window_resize().write_help(&mut std::io::stderr()).unwrap();
+            eprintln!();
+            return;
+        }
+
+        let id = id.unwrap().to_string();
+        let width = width.unwrap();
+        let height = height.unwrap();
+
+        let width: i32 = width.parse().unwrap();
+        let height: i32 = height.parse().unwrap();
+        self.log(format!("Resizing window \"{}\"", id));
+        self.event_queue.send(Event::Gui(GuiEvent::ResizeWindow(id, width, height))).unwrap();
+    }
+
+    fn execute_redraw(&self) {
+        self.event_queue.send(Event::Gui(GuiEvent::Redraw())).unwrap();
+    }
+
+    fn execute_clear(&self) {
+        self.event_queue.send(Event::Gui(GuiEvent::Clear())).unwrap();
+        self.log("Screen cleared.");
+    }
+}
 
 impl AltctrlInterface for Garfanzo {
-    fn launch(&self, sender: Sender<Event>, serial_receiver: Receiver<SerialEvent>) {
-        let sender_clone = sender.clone();
+    fn launch(&self, _: Sender<Event>, _: Receiver<SerialEvent>) {
+        self.repl(std::io::stdin().lock());
+    }
+}
 
-        thread::spawn(move || {
-            for message in serial_receiver.iter() {
-                match message {
-                    SerialEvent::Pressed(device, button) => {
-                        let string = format!("Button pressed: {:?} {:?}", device, button);
-                        sender_clone
-                            .send(Event::Gui(gui::GuiEvent::Log(string)))
-                            .unwrap();
-                    }
-                    SerialEvent::Released(device, button) => {
-                        let string = format!("Button released: {:?} {:?}", device, button);
-                        sender_clone
-                            .send(Event::Gui(gui::GuiEvent::Log(string)))
-                            .unwrap();
-                    }
-                }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subcommand_window() {
+        let mut app = Garfanzo::app();
+        let command = vec!["garfanzo", "window", "new", "0", "Hello, world", "Message", "bold", "10", "15", "20", "25"];
+        let result = app.get_matches_from_safe_borrow(command);
+        assert!(result.is_ok());
+
+        let matches = result.unwrap();
+        assert!(matches.subcommand_matches("window").is_some());
+        if let ("window", Some(sub)) = matches.subcommand() {
+            if let ("new", Some(sub)) = sub.subcommand() {
+                assert_eq!(sub.value_of("id"), Some("0"));
+                assert_eq!(sub.value_of("content"), Some("Hello, world"));
+                assert_eq!(sub.value_of("message"), Some("Message"));
+                assert_eq!(sub.value_of("style"), Some("bold"));
+                assert_eq!(sub.value_of("x_pos"), Some("10"));
+                assert_eq!(sub.value_of("y_pos"), Some("15"));
+                assert_eq!(sub.value_of("width"), Some("20"));
+                assert_eq!(sub.value_of("height"), Some("25"));
+            } else {
+                assert!(false);
             }
-        });
-
-        let stdin = io::stdin();
-        for line in stdin.lock().lines() {
-            match line {
-                Ok(command) => {
-                    let command = command.split('`').collect::<Vec<&str>>();
-                    if !command.is_empty() {
-                        match command[0] {
-                            "log" => {
-                                if command.len() > 1 {
-                                    match command[1] {
-                                        "put" => {
-                                            if command.len() == 3 {
-                                                notify(command[2], &sender);
-                                            }
-                                        },
-                                        "toggle" => {
-                                            sender.send(Event::Gui(gui::GuiEvent::ToggleConsole())).unwrap();
-                                        },
-                                        _ => {
-                                            invalid_command(&sender);
-                                        },
-                                    }
-                                }
-                            }
-                            "window" => {
-                                if command.len() > 1 {
-                                    match command[1] {
-                                        "new" => {
-                                            if command.len() >= 10 && command.len() <= 11 { // Remember to update this number when you add new shit to the window protocol
-                                                sender.send(Event::Gui(gui::GuiEvent::Log(format!("Creating window, \"{}\"", command[2]).to_string(),))).unwrap();
-                                                //TODO: Why can't I figure out this unwrap?
-                                                let mut priority = false;
-                                                if command.len() == 11 && command[10] == "!" {
-                                                    priority = true;
-                                                }
-                                                let window = protocol::WindowData {
-                                                    id:      command[2].to_string(),
-                                                    content: command[3].to_string(),
-                                                    message: command[4].to_string(),
-                                                    style:   command[5].to_string(),
-                                                    x_pos:   command[6].parse::<i32>().unwrap(),
-                                                    y_pos:   command[7].parse::<i32>().unwrap(),
-                                                    width:   command[8].parse::<i32>().unwrap(),
-                                                    height:  command[9].parse::<i32>().unwrap(),
-                                                    priority: priority,
-                                                };
-                                                sender.send(Event::Gui(gui::GuiEvent::CreateWindow(window))).unwrap();
-                                            } else {
-                                                invalid_command(&sender);
-                                            }
-                                        }
-                                        "close" => {
-                                            let window = command[2].to_string();
-                                            notify(format!("Closing window \"{}\"", &window).as_str(), &sender);
-                                            sender.send(Event::Gui(gui::GuiEvent::DestroyWindow(window))).unwrap();
-                                        }
-                                        "list" => {
-                                            sender.send(Event::Gui(gui::GuiEvent::List())).unwrap();
-                                        }
-                                        "move" => {
-                                            if command.len() == 5 {
-                                                notify(format!("Moving window \"{}\"", command[2]).as_str(), &sender);
-                                                sender.send(Event::Gui(gui::GuiEvent::MoveWindow(
-                                                    command[2].to_string(),
-                                                    command[3].parse::<i32>().unwrap(),
-                                                    command[4].parse::<i32>().unwrap(),
-                                                ))).unwrap();
-                                            }
-                                        }
-                                        "resize" => {
-                                            notify(format!("Resizing window \"{}\"", command[2]).as_str(), &sender);
-                                            sender.send(Event::Gui(gui::GuiEvent::ResizeWindow(
-                                                command[2].to_string(),
-                                                command[3].parse::<i32>().unwrap(),
-                                                command[4].parse::<i32>().unwrap(),
-                                            ))).unwrap();
-                                        }
-                                        _ => {
-                                            invalid_command(&sender);
-                                        }
-                                    }
-                                } else {
-                                    invalid_command(&sender);
-                                }
-                            },
-                            "redraw" => {
-                                sender.send(Event::Gui(gui::GuiEvent::Redraw())).unwrap();
-                            }
-                            "clear" => {
-                                sender.send(Event::Gui(gui::GuiEvent::Clear())).unwrap();
-                                notify("Screen cleared.", &sender);
-                            }
-                            "help" => {
-                                //(log, window(command (new, (id, content (Text, List, Scoreboard, ProgressBar), message (separate with | and then with +), x_pos, y_pos, width, height), move (id, x, y), resize (id, x, y), close)), clear, help) Separate arguments with \',\'";
-                                let help_message =
-                                    "===HOW TO USE GARFANZO===
-—————————————————————————
-log [put | toggle],
-window [
-    new[
-        id,
-        content[ T(ext) | L(ist) | SB (ScoreBoard) | PB (ProgressBar) ],
-        message (Separate elements with '|' and sub elements with ':'),
-        style[ (If styling Text, List, or ScoreBoard [bold | highlight | blink | underline]) | (If styling a ProgressBar [[low | blink], <character>]) ],
-        x_pos, y_pos,
-        width, height,
-        (Optionally, add '!' at the end of your command to allow overriding.
-        Separate arguments with '`')
-    ],
-    close[id],
-    list,
-    move[id, x, y],
-    resize[id, x, y]
-]
-redraw,
-clear,
-help
-"
-
-                                        // "[ log (put | toggle) ],
-                                        // [ window(
-                                        //     new(
-                                        //         id,
-                                        //         content(
-                                        //             T <text> | L <list> | SB <scoreboard> | PB <progressbar> )
-                                        //         message <separate with | and then with +>
-                                        //         style <For text, lists, and scoreboards (bold | highlight | blink | underline)> <For progress bars ()  | x_pos | y_pos | width | height) | close (id) | list | move (x | y) | resize (x | y )) ], [ redraw ], [ clear ], [ help ], Optionally, add '!' at the end of your command to allow overriding. Separate arguments with '`'."
-                                        .to_string();
-                                eprint!("{}", &help_message);
-                                // let window = protocol::WindowData {
-                                //     id:      "help".to_string(),
-                                //     content: "T".to_string(),
-                                //     message: message.to_string(),
-                                //     x_pos:   10,
-                                //     y_pos:   10,
-                                //     width:   40,
-                                //     height:  20,
-                                //     priority: true,
-                                // };
-                                // sender.send(Event::Gui(gui::GuiEvent::CreateWindow(window))).unwrap();
-                            }
-                            _ => {
-                                invalid_command(&sender);
-                            }
-                        }
-                    } else {
-                        invalid_command(&sender);
-                    }
-                }
-                Err(e) => {
-                    eprintln!("{}", e);
-                }
-            }
-        }
-        fn notify(info: &str, sender: &Sender<Event>) {
-            sender.send(Event::Gui(gui::GuiEvent::Log(info.to_string()))).unwrap();
-        }
-        fn invalid_command(sender: &Sender<Event>) {
-            sender.send(Event::Gui(gui::GuiEvent::Log("Invalid command received.".to_string(),))).unwrap();
+        } else {
+            assert!(false);
         }
     }
 }

--- a/src/garfanzo.rs
+++ b/src/garfanzo.rs
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn test_subcommand_window() {
         let mut app = Garfanzo::app();
-        let command = vec!["garfanzo", "window", "new", "0", "Hello, world", "Message", "bold", "10", "15", "20", "25"];
+        let command = vec!["window", "new", "0", "Hello, world", "Message", "bold", "10", "15", "20", "25"];
         let result = app.get_matches_from_safe_borrow(command);
         assert!(result.is_ok());
 

--- a/src/garfanzo.rs
+++ b/src/garfanzo.rs
@@ -106,7 +106,7 @@ impl Garfanzo {
     }
 
     fn subcommand_window_move<'a, 'b>() -> App<'a, 'b> {
-        SubCommand::with_name("move")
+        SubCommand::with_name("move").alias("mv")
             .about("Move an existing window to new coordinates")
             .arg(Arg::with_name("id").help("The ID of the window to move")
                 .index(1).takes_value(true))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate lazy_static;
+
 use std::sync::mpsc::{Receiver, Sender};
 
 pub mod gui;


### PR DESCRIPTION
This rewrite leverages clap in order to make command parsing easier. Rather than taking input from actual CLI arguments, it takes them from each line on STDIN after garfanzo is launched. Clap also constructs detailed help messages at each level. Invalid arguments will print the top-level help, whereas an incomplete subcommand will print the subcommand help. E.g. `window new` will print the help for the new window commands. The last thing to do here is finish out the `usage` section on `window_new` since I didn't know what all of those arguments do, then we might want to battle-test it a bit.